### PR TITLE
chore: add informative message for no subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -444,6 +444,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 file_path, disk_type, disk_name
             );
         }
+        None => {
+            println!("No subcommand was used. Use --help for usage information.");
+            return Ok(());
+        }
         _ => unreachable!("Exhaustive subcommand matching should prevent this"),
     }
 


### PR DESCRIPTION
- Add a new match arm to handle the case when no subcommand is provided
- Display a helpful message directing users to the --help option for usage information
- Ensure early return to avoid running unnecessary code